### PR TITLE
instead of jQuery event 'debouncedwidth' dispatch js event such that …

### DIFF
--- a/js/jquery.debouncedwidth.js
+++ b/js/jquery.debouncedwidth.js
@@ -51,7 +51,7 @@
                 // use requestAnimationFrame to prevent wrong trigger timings
                 rAF(function () {
                     while(index--) {
-                        $(elements[index]).trigger('debouncedwidth');
+                      elements[index].dispatchEvent(new Event('debouncedwidth'));
                     }
                 });
             }


### PR DESCRIPTION
instead of jQuery event 'debouncedwidth' dispatch js event such that JS / ES6 / TS implementations also can register event listeners on debouncedwidth